### PR TITLE
fix: version packages only after successful npm publish

### DIFF
--- a/.changeset/fix-version-timing.md
+++ b/.changeset/fix-version-timing.md
@@ -1,0 +1,5 @@
+---
+"@di-rs/rollercoaster": patch
+---
+
+Fix release workflow to only version and commit after successful npm publish. Prevents version bumps when publish fails.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,16 +45,6 @@ jobs:
             echo "has_changesets=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Version packages
-        if: steps.check-changesets.outputs.has_changesets == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          bun run version
-          git add .
-          git commit -m "chore: version packages [skip ci]"
-          git push
-
       - name: Build npm package (JS bundle)
         if: steps.check-changesets.outputs.has_changesets == 'true'
         run: bun run build:npm
@@ -79,14 +69,21 @@ jobs:
         # See: https://docs.npmjs.com/trusted-publishers/
         run: bun run release
 
-      - name: Get version and create tag
+      - name: Version packages and create tag
         if: steps.check-changesets.outputs.has_changesets == 'true'
         id: get-version
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          bun run version
+          git add .
+          git commit -m "chore: version packages [skip ci]"
+          
           VERSION=$(node -p "require('./package.json').version")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+          
           git tag -a "v$VERSION" -m "Release v$VERSION"
-          git push origin "v$VERSION"
+          git push origin HEAD --tags
 
       - name: Create GitHub Release
         if: steps.check-changesets.outputs.has_changesets == 'true'


### PR DESCRIPTION
## 🐛 Fix Version Timing Issue

**Problem:**
The release workflow was versioning packages and committing BEFORE publishing to npm. When the publish failed (e.g., OIDC not configured), the version was already bumped in the repo, creating orphaned version commits like https://github.com/di-rs/rollercoaster/commit/20ca6b7094d129f1761050f234578d1ce60ea44a

**Solution:**
Reordered the workflow steps:

### Before ❌
1. Version packages → commit → push
2. Build
3. Publish to npm (fails)
4. Create git tags

Result: Version 1.2.0 committed even though publish failed

### After ✅
1. Build npm bundle and executables
2. Publish to npm
3. **ONLY after successful publish:** Version packages → commit → tag → push

Result: Version only commits if publish succeeds

## 📦 Changes

- Moved "Version packages" step to **after** npm publish
- Combined versioning, tagging, and pushing into one atomic step
- Added changeset to bump version to 1.2.1 (patch)

## 🧪 Testing

After merging and configuring OIDC:
1. Workflow will build
2. Publish to npm
3. Only on success: bump version, commit, tag, push

If publish fails, no version commit is created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow to ensure version bumps occur only after successful package publication, preventing version increments if publishing fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->